### PR TITLE
Use npm registry reference in README install protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,18 @@ This is a plugin for the [Vuex-ORM](https://github.com/vuex-orm/vuex-orm) librar
 
 ## Installation
 
-Simply reference the github project in your `package.json`
+Install this plugin via npm or yarn.
 
-```javascript
-dependencies: {
-    ...
-    "vuexorm-softdelete-plugin": "git+https://github.com/tvillaren/vuexorm-softdelete-plugin.git"
-    ...
-}
+```bash
+$ npm install @vuex-orm/plugin-soft-delete
+
+$ yarn add @vuex-orm/plugin-soft-delete
 ```
-
-and run `npm install`.
 
 Then, you need to install the plugin as any VuexORM plugin. In your store initialization code, simply add:
 
 ```javascript
-import VuexORMSoftDeletePlugin from 'vuexorm-softdelete-plugin';
+import VuexORMSoftDeletePlugin from '@vuex-orm/plugin-soft-delete';
 ```
 
 and then


### PR DESCRIPTION
I've added npm registry reference to the install part of the README since the package seems to be published in npm (https://www.npmjs.com/package/@vuex-orm/plugin-soft-delete)